### PR TITLE
Fix delete query bug 😱

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -99,7 +99,8 @@ const xdelete = async (req, res, next) => {
 			} else { res.status(400).json({ message: "Invalid record Id" }) }
 		} else if (req.query.q) {
 			const query = helper.parse_query(req.query.q)
-
+			query['_box'] = req.box;
+			
 			const result = await Data.deleteMany(query);
 			res.json({ message: result.deletedCount + " Records removed." });
 		}


### PR DESCRIPTION
My previous PR for the delete query, introduced a bug, where using the query, will delete records in **other boxes!!!** when they meet the query criteria.   

This is a fix for this issue.  
I ran a local instance, and tested before and after the change to make sure I can reproduce the bug, and then see that it is actually gone.
