### PR TITLE
Add support for json-query syntax filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -224,6 +224,11 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
+    "json-query": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json-query/-/json-query-2.2.2.tgz",
+      "integrity": "sha1-tlWLijeUzNIXkmqjgCQyS3e0irE="
+    },
     "kareem": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-rate-limit": "^5.0.0",
+    "json-query": "^2.2.2",
     "mongoose": "^5.6.12"
   }
 }

--- a/src/model.js
+++ b/src/model.js
@@ -44,7 +44,6 @@ const xget = async (req, res, next) => {
 
 			let query = {};
 
-
 			if (req.query.q) {
 				query = helper.parse_query(req.query.q);
 			} else if (req.query.query_key && req.query.query_value) {
@@ -71,16 +70,12 @@ const xget = async (req, res, next) => {
 			if (req.collection) query['_collection'] = req.collection;
 			let records = await Data.find(query).skip(skip).limit(limit).sort(sort).exec();
 			
-
 			records = records.map(r => helper.responseBody(r, req.collection))
 
 			if (req.query.jq){
 				records = jsonQuery(req.query.jq, {
 				  data: records
 				}).value;
-
-				res.json(records);
-				return;
 			}
 
 			res.json(records);

--- a/src/model.js
+++ b/src/model.js
@@ -30,7 +30,6 @@ const xpost = async (req, res, next) => {
 };
 const xget = async (req, res, next) => {
 	try {
-		console.log("xget");
 		if (req.recordId) {
 			const record = await Data.findOne({ _id: req.recordId, _box: req.box }).exec();
 			res.json(helper.responseBody(record, req.collection));
@@ -72,15 +71,11 @@ const xget = async (req, res, next) => {
 			if (req.collection) query['_collection'] = req.collection;
 			let records = await Data.find(query).skip(skip).limit(limit).sort(sort).exec();
 			
-			console.log("before", records);
-
 			if (req.query.jq){
 				records = jsonQuery(req.query.jq, {
-				  // data: {"results": records}
 				  data: records
 				}).value;
 
-				console.log("after", records);
 				res.json(records);
 				return;
 			}

--- a/src/model.js
+++ b/src/model.js
@@ -71,6 +71,9 @@ const xget = async (req, res, next) => {
 			if (req.collection) query['_collection'] = req.collection;
 			let records = await Data.find(query).skip(skip).limit(limit).sort(sort).exec();
 			
+
+			records = records.map(r => helper.responseBody(r, req.collection))
+
 			if (req.query.jq){
 				records = jsonQuery(req.query.jq, {
 				  data: records
@@ -80,7 +83,7 @@ const xget = async (req, res, next) => {
 				return;
 			}
 
-			res.json(records.map(r => helper.responseBody(r, req.collection)));
+			res.json(records);
 		}
 	} catch (error) {
 		next(error);


### PR DESCRIPTION
Added an optional filtering using [json-query](https://github.com/auditassistant/json-query).
This should allow deep array filtering like the one requested in https://github.com/vasanthv/jsonbox/issues/30 . 

It is important to note (also mentioned in the readme) this is an optional extra filtering, and will not affect any of the existing behavior if not explicitly added by the user.  

Using the filter is by adding the `jq` url parameter. The supported syntax is detailed in the [json-query page](https://github.com/auditassistant/json-query)