### PR TITLE
Simplified Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:latest
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-COPY package.json /usr/src/app/
+COPY package.json .
 RUN npm install
-COPY . /usr/src/app
+COPY . .
 EXPOSE 3000
 CMD [ "npm", "start" ]


### PR DESCRIPTION
As per the docker documentation at https://docs.docker.com/engine/reference/builder/#workdir,
"If the WORKDIR doesn’t exist, it will be created even if it’s not used in any subsequent Dockerfile instruction".

Once the WORKDIR is set, . can be used to refer to it.