### PR TITLE
Allow IP whitelisting to access self hosted jsonbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -426,6 +426,17 @@
         "vary": "~1.1.2"
       }
     },
+    "express-ipfilter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.1.2.tgz",
+      "integrity": "sha512-dm1G3sVxlSbcOWSxfUTCo20ySyNQXJ4hJD5fuQJFoZlhkQvpbuDGBlh8AbFm1GwX85EWvfyhekOkvcydaXkBkg==",
+      "requires": {
+        "ip": "~1.1.0",
+        "lodash": "^4.17.11",
+        "proxy-addr": "^2.0.4",
+        "range_check": "^1.2.0"
+      }
+    },
     "express-rate-limit": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.1.1.tgz",
@@ -604,6 +615,16 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "ip6": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/ip6/-/ip6-0.0.4.tgz",
+      "integrity": "sha1-RMWp23njnUBSAbTXjROzhw5I2zE="
+    },
     "ipaddr.js": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
@@ -720,8 +741,7 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-      "dev": true
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -1071,6 +1091,22 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "range_check": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/range_check/-/range_check-1.4.0.tgz",
+      "integrity": "sha1-zYfHrGLEC6nfabhwPGBPYMN0hjU=",
+      "requires": {
+        "ip6": "0.0.4",
+        "ipaddr.js": "1.2"
+      },
+      "dependencies": {
+        "ipaddr.js": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+          "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
+        }
+      }
     },
     "raw-body": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"body-parser": "^1.19.0",
 		"cors": "^2.8.5",
 		"express": "^4.17.1",
+		"express-ipfilter": "^1.1.2",
 		"express-rate-limit": "^5.1.1",
 		"mongoose": "^5.9.5"
 	},

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const cors = require('cors');
 const config = require('./src/config');
 const routes = require('./src/routes');
 const ipfilter = require('express-ipfilter').IpFilter
+const IpDeniedError = require('express-ipfilter').IpDeniedError
 
 
 const app = express();
@@ -25,6 +26,13 @@ app.use(bodyParser.json());
 app.get('/v2', (req, res) => res.sendFile(path.join(__dirname, 'www/index.html')));
 
 app.use(routes);
+
+app.use((err, req, res, next) => {
+    console.error(err)
+    if (err instanceof IpDeniedError) {
+    	res.status(403).json({ message: "Forbidden" });
+	}
+});
 
 app.listen(config.PORT, err => {
 	if (err) console.error(err);

--- a/server.js
+++ b/server.js
@@ -4,18 +4,8 @@ const path = require('path');
 const cors = require('cors');
 const config = require('./src/config');
 const routes = require('./src/routes');
-const ipfilter = require('express-ipfilter').IpFilter
-const IpDeniedError = require('express-ipfilter').IpDeniedError
-
 
 const app = express();
-
-// Optionally use IP filter
-if (config.FILTER_IP_SET !== undefined 
-	&& Array.isArray(config.FILTER_IP_SET) 
-	&& config.FILTER_IP_SET.length > 0) {
-		app.use(ipfilter(config.FILTER_IP_SET, config.FILTER_OPTIONS));
-}
 
 app.enable('trust proxy');
 // set express server middlewares
@@ -26,13 +16,6 @@ app.use(bodyParser.json());
 app.get('/v2', (req, res) => res.sendFile(path.join(__dirname, 'www/index.html')));
 
 app.use(routes);
-
-app.use((err, req, res, next) => {
-    console.error(err)
-    if (err instanceof IpDeniedError) {
-    	res.status(403).json({ message: "Forbidden" });
-	}
-});
 
 app.listen(config.PORT, err => {
 	if (err) console.error(err);

--- a/server.js
+++ b/server.js
@@ -4,8 +4,17 @@ const path = require('path');
 const cors = require('cors');
 const config = require('./src/config');
 const routes = require('./src/routes');
+const ipfilter = require('express-ipfilter').IpFilter
+
 
 const app = express();
+
+// Optionally use IP filter
+if (config.FILTER_IP_SET !== undefined 
+	&& Array.isArray(config.FILTER_IP_SET) 
+	&& config.FILTER_IP_SET.length > 0) {
+		app.use(ipfilter(config.FILTER_IP_SET, config.FILTER_OPTIONS));
+}
 
 app.enable('trust proxy');
 // set express server middlewares

--- a/src/config.js
+++ b/src/config.js
@@ -5,4 +5,6 @@ module.exports = {
 	REQUEST_LIMIT_PER_HOUR: 100,
 	ENABLE_DATA_EXPIRY: true, // Once switched on the index will be be set in mongodb. Might need to remove it in order to switch off the behaviour
 	DATA_EXPIRY_IN_DAYS: 30,
+	FILTER_IP_SET: [],  // example ['172.29.0.1']
+	FILTER_OPTIONS: { mode: 'allow' },
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -38,8 +38,9 @@ router.use((err, req, res, next) => {
 	console.error(err);
 	if (err instanceof IpDeniedError) {
 		res.status(403).json({ message: "Forbidden" });
+	} else {
+		res.status(err.statusCode || 500).json({ message: err.message });
 	}
-	res.status(err.statusCode || 500).json({ message: err.message });
 });
 
 module.exports = router;

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,6 +5,16 @@ const model = require("./model");
 const config = require("./config");
 const validators = require("./validators");
 
+const ipfilter = require('express-ipfilter').IpFilter
+const IpDeniedError = require('express-ipfilter').IpDeniedError
+
+// Optionally use IP filter
+if (config.FILTER_IP_SET !== undefined &&
+	Array.isArray(config.FILTER_IP_SET) &&
+	config.FILTER_IP_SET.length > 0) {
+	router.use(ipfilter(config.FILTER_IP_SET, config.FILTER_OPTIONS));
+}
+
 router.get("/_meta/:boxId", model.xmeta);
 
 // list of all validators to be in place
@@ -26,6 +36,9 @@ router.delete("/*", model.xdelete);
  */
 router.use((err, req, res, next) => {
 	console.error(err);
+	if (err instanceof IpDeniedError) {
+		res.status(403).json({ message: "Forbidden" });
+	}
 	res.status(err.statusCode || 500).json({ message: err.message });
 });
 


### PR DESCRIPTION
Addressing feature request #69 

Using https://github.com/jetersen/express-ipfilter

In the default config, the filtering is not activated, in order to prevent any overhead.

Only when defining `FILTER_IP_SET` in config.js to a value other than `[]`, will the filtering be enabled.